### PR TITLE
Bugfix alias feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "symfony/dependency-injection": "^2.8|^3.4|^4.3",
         "symfony/config": "^2.8|^3.4|^4.3",
         "symfony/yaml": "^2.8|^3.4|^4.3",
-        "friendsofphp/php-cs-fixer": "^1.1|^2.15"
+        "friendsofphp/php-cs-fixer": "^1.1|^2.15",
+        "phpunit/phpunit": "7"
     }
 }

--- a/src/Services/QueryBuilder.php
+++ b/src/Services/QueryBuilder.php
@@ -231,7 +231,7 @@ class QueryBuilder implements QueryBuilderInterface
             $filterData['entityname'] = $filter->getEntityName();
         }
 
-        if (!is_array($filter->getValue()) && $filter->getValue()) {
+        if (!is_array($filter->getValue()) && null !== $filter->getValue()) {
             $filterData['value'] = $filter->getValue();
         }
 
@@ -269,6 +269,10 @@ class QueryBuilder implements QueryBuilderInterface
 
         if (null !== $relation->getIntersect()) {
             $joinParameters['intersect'] = $this->boolToString($relation->getIntersect());
+        }
+
+        if (null !== $relation->getAlias()) {
+            $joinParameters['alias'] = $relation->getAlias();
         }
 
         $linkedRelation = $element->appendChild($this->createDomElement('link-entity', $joinParameters));

--- a/src/Services/QueryBuilderObject/Relation.php
+++ b/src/Services/QueryBuilderObject/Relation.php
@@ -30,9 +30,9 @@ class Relation
     private $intersect;
 
     /**
-     * @var array
+     * @var array|Attribute[]|null
      */
-    private $attributes = [];
+    private $attributes = null;
 
     /**
      * @var array|Sort[]
@@ -151,7 +151,7 @@ class Relation
         return $this;
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return $this->filters;
     }

--- a/src/Services/QueryBuilderObject/Relation.php
+++ b/src/Services/QueryBuilderObject/Relation.php
@@ -32,7 +32,7 @@ class Relation
     /**
      * @var array|Attribute[]|null
      */
-    private $attributes = null;
+    private $attributes = [];
 
     /**
      * @var array|Sort[]
@@ -106,7 +106,7 @@ class Relation
         return $this->attributes;
     }
 
-    public function setAttributes(array $attributes): self
+    public function setAttributes(?array $attributes): self
     {
         $this->attributes = $attributes;
 

--- a/src/Services/QueryBuilderObject/Relation.php
+++ b/src/Services/QueryBuilderObject/Relation.php
@@ -50,6 +50,11 @@ class Relation
     private $filters = [];
 
     /**
+     * @var string
+     */
+    private $alias;
+
+    /**
      * @deprecated v.1.0.1 $entityName no longer supports nullable value
      * @deprecated v.1.0.1 $to no longer supports nullable value
      */
@@ -187,5 +192,17 @@ class Relation
         $this->intersect = $intersect;
 
         return $this;
+    }
+
+    public function setAlias(string $alias): self
+    {
+        $this->alias = $alias;
+
+        return $this;
+    }
+
+    public function getAlias(): ?string
+    {
+        return $this->alias;
     }
 }

--- a/src/Services/QueryBuilderObject/Relation.php
+++ b/src/Services/QueryBuilderObject/Relation.php
@@ -101,7 +101,7 @@ class Relation
         return $this;
     }
 
-    public function getAttributes(): array
+    public function getAttributes(): ?array
     {
         return $this->attributes;
     }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -6,6 +6,15 @@ use Horlyk\Bundle\FetchXmlBundle\Services\QueryBuilderObject\Filter;
 
 class FilterTest extends AbstractQueryBuilderTest
 {
+    public function testFilterEmptyValue()
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder->addFilter(new Filter('name','','ne'));
+
+        $expected = '<fetch><entity name="user"><condition attribute="name" operator="ne" value=""/><all-attributes/></entity></fetch>';
+        $this->assertEquals($expected, $queryBuilder->getQuery());
+    }
+
     public function testFilter()
     {
         $queryBuilder = $this->getQueryBuilder();

--- a/tests/RelationTest.php
+++ b/tests/RelationTest.php
@@ -25,8 +25,10 @@ class RelationTest extends AbstractQueryBuilderTest
         ];
 
         $queryBuilder->addRelation($data[0]);
-        $this->assertEquals('<fetch><entity name="user"><link-entity name="phone" to="user"/><all-attributes/></entity></fetch>',
-            $queryBuilder->getQuery());
+        $this->assertEquals(
+            '<fetch><entity name="user"><link-entity name="phone" to="user"/><all-attributes/></entity></fetch>',
+            $queryBuilder->getQuery()
+        );
 
         $queryBuilder->addRelation($data[1]);
         $this->assertEquals(
@@ -55,16 +57,19 @@ class RelationTest extends AbstractQueryBuilderTest
 
         $relation = (new Relation('address', 'user', 'user_id'))
             ->setJoinType('outer')
-            ->setIntersect(true)
-        ;
+            ->setIntersect(true);
 
         $queryBuilder->addRelation($relation);
-        $this->assertEquals('<fetch><entity name="user"><link-entity name="address" to="user" from="user_id" link-type="outer" intersect="true"/><all-attributes/></entity></fetch>',
-            $queryBuilder->getQuery());
+        $this->assertEquals(
+            '<fetch><entity name="user"><link-entity name="address" to="user" from="user_id" link-type="outer" intersect="true"/><all-attributes/></entity></fetch>',
+            $queryBuilder->getQuery()
+        );
 
         $relation->setIntersect(false);
-        $this->assertEquals('<fetch><entity name="user"><link-entity name="address" to="user" from="user_id" link-type="outer" intersect="false"/><all-attributes/></entity></fetch>',
-            $queryBuilder->getQuery());
+        $this->assertEquals(
+            '<fetch><entity name="user"><link-entity name="address" to="user" from="user_id" link-type="outer" intersect="false"/><all-attributes/></entity></fetch>',
+            $queryBuilder->getQuery()
+        );
 
         $queryBuilder->setRelations([]);
     }
@@ -78,12 +83,16 @@ class RelationTest extends AbstractQueryBuilderTest
 
         $relation->addFilter(new Filter('city', 'Babruysk'));
 
-        $this->assertEquals('<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"><filter><condition attribute="city" operator="eq" value="Babruysk"/></filter></link-entity><all-attributes/></entity></fetch>',
-            $queryBuilder->getQuery());
+        $this->assertEquals(
+            '<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"><filter><condition attribute="city" operator="eq" value="Babruysk"/></filter></link-entity><all-attributes/></entity></fetch>',
+            $queryBuilder->getQuery()
+        );
 
         $relation->addFilter(new Filter('country', 'Belarus'));
-        $this->assertEquals('<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"><filter><condition attribute="city" operator="eq" value="Babruysk"/><condition attribute="country" operator="eq" value="Belarus"/></filter></link-entity><all-attributes/></entity></fetch>',
-            $queryBuilder->getQuery());
+        $this->assertEquals(
+            '<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"><filter><condition attribute="city" operator="eq" value="Babruysk"/><condition attribute="country" operator="eq" value="Belarus"/></filter></link-entity><all-attributes/></entity></fetch>',
+            $queryBuilder->getQuery()
+        );
 
         $relation->setFilters([]);
 
@@ -99,12 +108,16 @@ class RelationTest extends AbstractQueryBuilderTest
 
         $relation->addSortOrder(new Sort('city'));
 
-        $this->assertEquals('<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"><order attribute="city" descending="false"/></link-entity><all-attributes/></entity></fetch>',
-            $queryBuilder->getQuery());
+        $this->assertEquals(
+            '<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"><order attribute="city" descending="false"/></link-entity><all-attributes/></entity></fetch>',
+            $queryBuilder->getQuery()
+        );
 
         $relation->addSortOrder(new Sort('zip', 'desc'));
-        $this->assertEquals('<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"><order attribute="city" descending="false"/><order attribute="zip" descending="true"/></link-entity><all-attributes/></entity></fetch>',
-            $queryBuilder->getQuery());
+        $this->assertEquals(
+            '<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"><order attribute="city" descending="false"/><order attribute="zip" descending="true"/></link-entity><all-attributes/></entity></fetch>',
+            $queryBuilder->getQuery()
+        );
 
         $relation->setSorts([]);
 
@@ -123,12 +136,50 @@ class RelationTest extends AbstractQueryBuilderTest
 
         $relation->addRelation($relationType);
 
-        $this->assertEquals('<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"><link-entity name="type" to="address" from="address_id"/></link-entity><all-attributes/></entity></fetch>',
-            $queryBuilder->getQuery());
+        $this->assertEquals(
+            '<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"><link-entity name="type" to="address" from="address_id"/></link-entity><all-attributes/></entity></fetch>',
+            $queryBuilder->getQuery()
+        );
 
         $relation->setRelations([]);
         $this->assertEquals([], $relation->getRelations());
 
-        $this->assertEquals('<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"/><all-attributes/></entity></fetch>', $queryBuilder->getQuery());
+        $this->assertEquals(
+            '<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"/><all-attributes/></entity></fetch>',
+            $queryBuilder->getQuery()
+        );
+    }
+
+    /**
+     * Relation with attributes=[] should render no attributes
+     *
+     * @throws \Horlyk\Bundle\FetchXmlBundle\Exception\QueryBuilderException
+     */
+    public function testRelationNoAttributes()
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $relation = (new Relation('address', 'user', 'user_id'));
+        $relation->setAttributes([]);
+        $queryBuilder->addRelation($relation);
+
+        $expected = '<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"/><all-attributes/></entity></fetch>';
+        $this->assertEquals($expected, $queryBuilder->getQuery());
+    }
+
+
+    /**
+     * Relation with attributes=null should render a all-attributes node
+     *
+     * @throws \Horlyk\Bundle\FetchXmlBundle\Exception\QueryBuilderException
+     */
+    public function testRelationAllAttributes()
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $relation = (new Relation('address', 'user', 'user_id'));
+        $relation->setAttributes(null);
+        $queryBuilder->addRelation($relation);
+
+        $expected = '<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"><all-attributes/></link-entity><all-attributes/></entity></fetch>';
+        $this->assertEquals($expected, $queryBuilder->getQuery());
     }
 }

--- a/tests/RelationTest.php
+++ b/tests/RelationTest.php
@@ -182,4 +182,16 @@ class RelationTest extends AbstractQueryBuilderTest
         $expected = '<fetch><entity name="user"><link-entity name="address" to="user" from="user_id"><all-attributes/></link-entity><all-attributes/></entity></fetch>';
         $this->assertEquals($expected, $queryBuilder->getQuery());
     }
+
+    public function testRelationAlias()
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $relation = (new Relation('address', 'user', 'user_id'));
+        $relation->setAttributes([]);
+        $relation->setAlias('abc');
+        $queryBuilder->addRelation($relation);
+
+        $expected = '<fetch><entity name="user"><link-entity name="address" to="user" from="user_id" alias="abc"/><all-attributes/></entity></fetch>';
+        $this->assertEquals($expected, $queryBuilder->getQuery());
+    }
 }


### PR DESCRIPTION
Fixes:
- filters: empty string value not included in query
- adds all-atributes in relations if no attributes specified.

Features:
- alias option for relations